### PR TITLE
Add badges and license information to README for better visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Open the frontend in your web browser by navigating to the index.html file locat
 
 Project Structure
 
-
 ├── catalyst_train.csv          
 ├── online_testcases.csv        
 ├── main.py     
@@ -73,3 +72,15 @@ Project Structure
 Author
 
 Ayush Mann - Initial work - https://github.com/AyushMann29/GrabHack-Project-Nova
+
+## Badges
+
+[![GitHub stars](https://img.shields.io/github/stars/AyushMann29/GrabHack-Project-Nova?style=social)](https://github.com/AyushMann29/GrabHack-Project-Nova/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/AyushMann29/GrabHack-Project-Nova?style=social)](https://github.com/AyushMann29/GrabHack-Project-Nova/network/members)
+[![GitHub issues](https://img.shields.io/github/issues/AyushMann29/GrabHack-Project-Nova)](https://github.com/AyushMann29/GrabHack-Project-Nova/issues)
+[![License](https://img.shields.io/github/license/AyushMann29/GrabHack-Project-Nova)](https://github.com/AyushMann29/GrabHack-Project-Nova/blob/main/LICENSE)
+
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Hi @AyushMann29 
This PR enhances the project's README by adding useful badges for GitHub stars, forks, issues, and license status. It also includes a license section with proper mention of the MIT License and link to the LICENSE file.

These additions improve the visual appeal and provide at-a-glance information about the repository's health and licensing, making it more professional and trustworthy.

Please review the changes and consider merging to enhance the documentation quality.
References #5 & #8 

Thank you!